### PR TITLE
Load styles and scripts in parallel

### DIFF
--- a/src/payline-helper.js
+++ b/src/payline-helper.js
@@ -28,7 +28,7 @@ function loadStyle(url) {
 export const loadPayline = (isHomologation = false) => {
   if(isHomologation){
     return Promise.all([
-      loadScript("https://homologation-payment.cdn.payline.com/scripts/widget-min.js",
+      loadScript("https://homologation-payment.cdn.payline.com/scripts/widget-min.js"),
       loadStyle("https://homologation-payment.cdn.payline.com/styles/widget-min.css"),
     ]);
   } else {

--- a/src/payline-helper.js
+++ b/src/payline-helper.js
@@ -25,14 +25,14 @@ function loadStyle(url) {
   })
 }
 
-export const loadPayline = async (isHomologation = false) => {
+export const loadPayline = (isHomologation = false) => {
   if(isHomologation){
-    await Promise.all([
+    return Promise.all([
       loadScript("https://homologation-payment.cdn.payline.com/scripts/widget-min.js",
       loadStyle("https://homologation-payment.cdn.payline.com/styles/widget-min.css"),
     ]);
   } else {
-    await Promise.all([
+    return Promise.all([
       loadScript("https://payment.payline.com/scripts/widget-min.js"),
       loadStyle("https://payment.payline.com/styles/widget-min.css"),
     ]);

--- a/src/payline-helper.js
+++ b/src/payline-helper.js
@@ -27,10 +27,14 @@ function loadStyle(url) {
 
 export const loadPayline = async (isHomologation = false) => {
   if(isHomologation){
-    await loadScript("https://homologation-payment.cdn.payline.com/scripts/widget-min.js");
-    await loadStyle("https://homologation-payment.cdn.payline.com/styles/widget-min.css");
+    await Promise.all([
+      loadScript("https://homologation-payment.cdn.payline.com/scripts/widget-min.js",
+      loadStyle("https://homologation-payment.cdn.payline.com/styles/widget-min.css"),
+    ]);
   } else {
-    await loadScript("https://payment.payline.com/scripts/widget-min.js");
-    await loadStyle("https://payment.payline.com/styles/widget-min.css");
+    await Promise.all([
+      loadScript("https://payment.payline.com/scripts/widget-min.js"),
+      loadStyle("https://payment.payline.com/styles/widget-min.css"),
+    ]);
   }
 };


### PR DESCRIPTION
Instead of loading the style after the script sequentially, load them in parallel for a faster loading