### PR TITLE
Fix payline not initializing by itself

### DIFF
--- a/src/component/VuePaylineWrapper.vue
+++ b/src/component/VuePaylineWrapper.vue
@@ -66,6 +66,11 @@ export default {
           this.initPayline(this.token);
         }
       }
+    },
+    payline(v) {
+      if (v) {
+          this.initPayline(this.token);
+      }
     }
   },
   computed: {


### PR DESCRIPTION
Follow up of #2 
Without it, we need to call window.Payline.Api.reset manually