### PR TITLE
Add timeout to init payline after script loaded

### DIFF
--- a/src/component/VuePaylineWrapper.vue
+++ b/src/component/VuePaylineWrapper.vue
@@ -69,7 +69,9 @@ export default {
     },
     payline(v) {
       if (v) {
-          this.initPayline(this.token);
+          setTimeout(() => {
+            this.initPayline(this.token);
+          }, 15);
       }
     }
   },


### PR DESCRIPTION
Sorry, another follow up after more and more debugging (Promise it's the last one)

For some reason Payline takes some time, because if it's initialised within less than 3ms of the script loaded it will initialise but display a blank page
A timeout fixes the issue correctly